### PR TITLE
Pull class descriptions instead of pushing them

### DIFF
--- a/protocol.js
+++ b/protocol.js
@@ -22,7 +22,7 @@ export default class JPCProtocol extends BaseProtocol {
   }
 
   async getRemoteStartObject() {
-    return this.mapIncomingObjects(await this.callRemote("start"));
+    return await this.mapIncomingObjects(await this.callRemote("start"));
   }
 
   /**


### PR DESCRIPTION
This allows the client to be reloaded and it will re-request class descriptions from the server as necessary.